### PR TITLE
Allow column name to differ from case class field using @CqlColumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS persons (
   id TEXT,
   name TEXT,
   age INT,
-  addresses frozen<set<address>>,
+  past_addresses frozen<set<address>>,
   PRIMARY KEY ((id), age)
 );
 ```
@@ -76,6 +76,7 @@ If we want to read and write data to this table, we create case classes that mir
 along with adding codecs for each datatype:
 
 ```scala
+import io.kaizensolutions.virgil.annotations.CqlColumn
 import io.kaizensolutions.virgil.codecs._
 
 final case class Info(favorite: Boolean, comment: String)
@@ -93,12 +94,20 @@ object Address {
 }
 
 // Note: This is the top level row, we write out its components so we don't need an Encoder for the whole Person
-final case class Person(id: String, name: String, age: Int, addresses: Set[Address])
+final case class Person(
+  id: String, 
+  name: String, 
+  age: Int, 
+  @CqlColumn("past_addresses") addresses: Set[Address]
+)
 
 object Person {
   implicit val decoderPerson: CqlDecoder[Person] = CqlDecoder.derive[Person]
 }
 ```
+
+Note that the `CqlColumn` annotation can be used if the column/field name in the Cassandra table is different from the 
+Scala representation. This can also be used inside User Defined Types as well.
 
 ### Writing data
 

--- a/src/main/scala/io/kaizensolutions/virgil/annotations/CqlColumn.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/annotations/CqlColumn.scala
@@ -1,0 +1,10 @@
+package io.kaizensolutions.virgil.annotations
+
+import scala.annotation.StaticAnnotation
+
+final case class CqlColumn(name: String) extends StaticAnnotation
+
+object CqlColumn {
+  @inline def extractFieldName(annotations: Seq[Any]): Option[String] =
+    annotations.collectFirst { case CqlColumn(name) => name }
+}

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlColumnDecoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlColumnDecoder.scala
@@ -2,6 +2,7 @@ package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.cql.Row
 import com.datastax.oss.driver.api.core.data.{CqlDuration, GettableByName, TupleValue, UdtValue}
+import io.kaizensolutions.virgil.annotations
 import magnolia1.{CaseClass, Magnolia}
 
 import java.util
@@ -327,8 +328,11 @@ trait UdtColumnDecoderMagnoliaDerivation {
   def join[T](ctx: CaseClass[CqlColumnDecoder, T]): CqlColumnDecoder.WithDriver[T, UdtValue] =
     CqlColumnDecoder.fromUdtValue { udtValue =>
       ctx.construct { param =>
-        val fieldName = param.label
-        val reader    = param.typeclass
+        val fieldName = {
+          val default = param.label
+          annotations.CqlColumn.extractFieldName(param.annotations).getOrElse(default)
+        }
+        val reader = param.typeclass
         reader.decodeFieldByName(udtValue, fieldName)
       }
     }

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlColumnEncoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlColumnEncoder.scala
@@ -2,6 +2,7 @@ package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.`type`._
 import com.datastax.oss.driver.api.core.data.{CqlDuration, SettableByName, TupleValue, UdtValue}
+import io.kaizensolutions.virgil.annotations
 import magnolia1._
 
 import java.net.InetAddress
@@ -657,7 +658,11 @@ trait UdtEncoderMagnoliaDerivation {
   def join[T](ctx: CaseClass[CqlColumnEncoder, T]): CqlColumnEncoder.WithDriver[T, UdtValue] =
     CqlColumnEncoder.udt[T] { (scalaValue, udtValue) =>
       ctx.parameters.foldLeft(udtValue) { case (acc, p) =>
-        p.typeclass.encodeFieldByName(p.label, p.dereference(scalaValue), acc)
+        val fieldName = {
+          val default = p.label
+          annotations.CqlColumn.extractFieldName(p.annotations).getOrElse(default)
+        }
+        p.typeclass.encodeFieldByName(fieldName, p.dereference(scalaValue), acc)
       }
     }
 

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlDecoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlDecoder.scala
@@ -1,6 +1,7 @@
 package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.cql.Row
+import io.kaizensolutions.virgil.annotations
 import magnolia1._
 
 /**
@@ -21,8 +22,11 @@ object CqlDecoder {
   def join[T](ctx: CaseClass[CqlColumnDecoder, T]): CqlColumnDecoder.WithDriver[T, Row] =
     CqlColumnDecoder.fromRow { row =>
       ctx.construct { param =>
-        val fieldName = param.label
-        val reader    = param.typeclass
+        val fieldName = {
+          val default = param.label
+          annotations.CqlColumn.extractFieldName(param.annotations).getOrElse(default)
+        }
+        val reader = param.typeclass
         reader.decodeFieldByName(row, fieldName)
       }
     }

--- a/src/test/resources/migrations.cql
+++ b/src/test/resources/migrations.cql
@@ -73,9 +73,9 @@ CREATE TABLE userdefinedtypesspec_heavilynestedudttable
 CREATE TABLE collectionspec_simplecollectiontable
 (
     id       INT PRIMARY KEY,
-    mapTest  FROZEN<MAP<INT,TEXT>>,
-    setTest  FROZEN<SET<BIGINT>>,
-    listTest FROZEN<LIST<TEXT>>
+    map_test  FROZEN<MAP<INT,TEXT>>,
+    set_test  FROZEN<SET<BIGINT>>,
+    list_test FROZEN<LIST<TEXT>>
 );
 
 CREATE TABLE collectionspec_nestedcollectiontable

--- a/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
@@ -1,6 +1,7 @@
 package io.kaizensolutions.virgil
 
 import com.datastax.oss.driver.api.core.uuid.Uuids
+import io.kaizensolutions.virgil.annotations.CqlColumn
 import io.kaizensolutions.virgil.codecs.CqlDecoder
 import io.kaizensolutions.virgil.configuration.{ConsistencyLevel, ExecutionAttributes}
 import io.kaizensolutions.virgil.cql._
@@ -43,7 +44,7 @@ object CQLExecutorSpec {
             .runCollect
             .map(results =>
               assertTrue(results.forall { r =>
-                import r.{query_string => query}
+                import r._
 
                 query.contains("SELECT") ||
                 query.contains("UPDATE") ||
@@ -133,9 +134,11 @@ object CQLExecutorSpec {
       }
 }
 
-final case class SystemLocalResponse(`system.now()`: UUID) {
+final case class SystemLocalResponse(
+  @CqlColumn("system.now()") now: UUID
+) {
   def time: Either[Throwable, Long] =
-    Try(Uuids.unixTimestamp(`system.now()`)).toEither
+    Try(Uuids.unixTimestamp(now)).toEither
 }
 object SystemLocalResponse {
   implicit val decoderForSystemLocalResponse: CqlDecoder[SystemLocalResponse] =
@@ -143,9 +146,9 @@ object SystemLocalResponse {
 }
 
 final case class PreparedStatementsResponse(
-  prepared_id: ByteBuffer,
-  logged_keyspace: Option[String],
-  query_string: String
+  @CqlColumn("prepared_id") preparedId: ByteBuffer,
+  @CqlColumn("logged_keyspace") keyspace: Option[String],
+  @CqlColumn("query_string") query: String
 )
 object PreparedStatementsResponse {
   implicit val decoderForPreparedStatementsResponse: CqlDecoder[PreparedStatementsResponse] =

--- a/src/test/scala/io/kaizensolutions/virgil/CollectionsSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/CollectionsSpec.scala
@@ -1,5 +1,6 @@
 package io.kaizensolutions.virgil
 
+import io.kaizensolutions.virgil.annotations.CqlColumn
 import io.kaizensolutions.virgil.codecs.CqlDecoder
 import io.kaizensolutions.virgil.dsl._
 import zio.Has
@@ -34,9 +35,9 @@ object CollectionsSpec {
 
 final case class SimpleCollectionRow(
   id: Int,
-  mapTest: Map[Int, String],
-  setTest: Set[Long],
-  listTest: List[String]
+  @CqlColumn("map_test") mapTest: Map[Int, String],
+  @CqlColumn("set_test") setTest: Set[Long],
+  @CqlColumn("list_test") listTest: List[String]
 )
 object SimpleCollectionRow {
   implicit val decoderForSimpleCollectionRow: CqlDecoder[SimpleCollectionRow] =
@@ -45,18 +46,18 @@ object SimpleCollectionRow {
   def insert(in: SimpleCollectionRow): CQL[MutationResult] =
     InsertBuilder("collectionspec_simplecollectiontable")
       .value("id", in.id)
-      .value("mapTest", in.mapTest)
-      .value("setTest", in.setTest)
-      .value("listTest", in.listTest)
+      .value("map_test", in.mapTest)
+      .value("set_test", in.setTest)
+      .value("list_test", in.listTest)
       .build
 
   def select(id: Int): CQL[SimpleCollectionRow] =
     SelectBuilder
       .from("collectionspec_simplecollectiontable")
       .column("id")
-      .column("mapTest")
-      .column("setTest")
-      .column("listTest")
+      .column("map_test")
+      .column("set_test")
+      .column("list_test")
       .where("id" === id)
       .build[SimpleCollectionRow]
 

--- a/src/test/scala/io/kaizensolutions/virgil/UserDefinedTypesSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/UserDefinedTypesSpec.scala
@@ -1,5 +1,7 @@
 package io.kaizensolutions.virgil
 
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.codecs._
 import io.kaizensolutions.virgil.cql._
 import io.kaizensolutions.virgil.dsl._
 import zio.Has
@@ -8,7 +10,6 @@ import zio.random.Random
 import zio.test.TestAspect._
 import zio.test._
 import zio.test.environment.Live
-import io.kaizensolutions.virgil.codecs._
 
 import java.time.{LocalDate, LocalTime}
 
@@ -98,7 +99,7 @@ object UDT_Address {
 
 final case class UDT_Email(
   username: String,
-  domain_name: String,
+  @CqlColumn("domain_name") domainName: String,
   domain: String
 )
 object UDT_Email {


### PR DESCRIPTION
Add @CqlColumn annotation which allows you to specify a Cassandra column name instead of using the case class field label name

Closes https://github.com/kaizen-solutions/virgil/issues/30