### PR TITLE
Implement query timeouts

### DIFF
--- a/src/main/scala/io/kaizensolutions/virgil/CQL.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQL.scala
@@ -7,6 +7,7 @@ import io.kaizensolutions.virgil.dsl.{Assignment, Relation}
 import io.kaizensolutions.virgil.internal.Proofs._
 import io.kaizensolutions.virgil.internal.{BindMarkers, PullMode, QueryType}
 import zio._
+import zio.duration.Duration
 import zio.stream.ZStream
 
 final case class CQL[+Result] private (
@@ -83,6 +84,9 @@ final case class CQL[+Result] private (
       case _: CQLType.Batch    => sys.error("It is not possible to take a batch")
     }
   }
+
+  def timeout(in: Duration): CQL[Result] =
+    self.withAttributes(self.executionAttributes.withTimeout(in))
 
   def withAttributes(in: ExecutionAttributes): CQL[Result] =
     copy(executionAttributes = in)

--- a/src/main/scala/io/kaizensolutions/virgil/CQL.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQL.scala
@@ -71,6 +71,10 @@ final case class CQL[+Result] private (
   def executePage[Result1 >: Result](state: Option[PageState] = None): RIO[Has[CQLExecutor], Paged[Result1]] =
     CQLExecutor.executePage(self, state)
 
+  def pageSize(in: Int): CQL[Result] =
+    if (in > 0) self.withAttributes(self.executionAttributes.copy(pageSize = Option(in)))
+    else self
+
   def take[Result1 >: Result](n: Long)(implicit ev: Result1 <:!< MutationResult): CQL[Result1] = {
     val _ = ev
     val adjustN = n match {

--- a/src/test/resources/migrations.cql
+++ b/src/test/resources/migrations.cql
@@ -19,6 +19,13 @@ CREATE TABLE IF NOT EXISTS ziocassandrasessionspec_selectPage
     PRIMARY KEY ((id), bucket)
 );
 
+CREATE TABLE IF NOT EXISTS ziocassandrasessionspec_timeoutcheck
+(
+    id           INT PRIMARY KEY,
+    info         TEXT,
+    another_info TEXT
+);
+
 CREATE TYPE udt_address (
     number INT,
     street TEXT,
@@ -72,7 +79,7 @@ CREATE TABLE userdefinedtypesspec_heavilynestedudttable
 
 CREATE TABLE collectionspec_simplecollectiontable
 (
-    id       INT PRIMARY KEY,
+    id        INT PRIMARY KEY,
     map_test  FROZEN<MAP<INT,TEXT>>,
     set_test  FROZEN<SET<BIGINT>>,
     list_test FROZEN<LIST<TEXT>>
@@ -95,25 +102,27 @@ CREATE TABLE collectionspec_nestedcollectiontable
 CREATE TYPE cursorspec_note(
     data TEXT,
     ip INET
-);
+    );
 
 CREATE TYPE cursorspec_address(
-   street TEXT,
-   city TEXT,
-   state TEXT,
-   zip TEXT,
-   note frozen<cursorspec_note>
-);
+    street TEXT,
+    city TEXT,
+    state TEXT,
+    zip TEXT,
+    note frozen<cursorspec_note>
+    );
 
-CREATE TABLE cursorspec_cursorexampletable(
-    id BIGINT PRIMARY KEY,
-    name TEXT,
+CREATE TABLE cursorspec_cursorexampletable
+(
+    id           BIGINT PRIMARY KEY,
+    name         TEXT,
     may_be_empty TEXT,
-    age SMALLINT,
-    addresses frozen<list<cursorspec_address>>,
+    age          SMALLINT,
+    addresses    frozen<list<cursorspec_address>>,
 );
 
-CREATE TABLE updatebuilderspec_person(
+CREATE TABLE updatebuilderspec_person
+(
     id   INT PRIMARY KEY,
     name TEXT,
     age  INT

--- a/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
@@ -71,5 +71,5 @@ object AllTests extends DefaultRunnableSpec {
             CursorSpec.cursorSpec +
             UpdateBuilderSpec.updateBuilderSpec
         ).provideCustomLayerShared(dependencies)
-    } @@ parallel
+    } @@ parallel @@ timed
 }

--- a/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
@@ -41,7 +41,7 @@ object AllTests extends DefaultRunnableSpec {
     ZLayer.requires[Blocking] ++ containerLayer >+> sessionLayer
   }
 
-  def runMigration(executor: CQLExecutor, fileName: String): ZIO[Blocking, Throwable, Unit] = {
+  def runMigration(cql: CQLExecutor, fileName: String): ZIO[Blocking, Throwable, Unit] = {
     val migrationCql =
       ZStream
         .fromEffect(effectBlocking(scala.io.Source.fromResource(fileName).getLines()))
@@ -57,7 +57,7 @@ object AllTests extends DefaultRunnableSpec {
 
     for {
       migrations <- migrationCql
-      _          <- ZIO.foreach_(migrations)(str => executor.execute(str.asCql.mutation).runDrain)
+      _          <- ZIO.foreach_(migrations)(str => cql.execute(str.asCql.mutation).runDrain)
     } yield ()
   }
 
@@ -65,7 +65,7 @@ object AllTests extends DefaultRunnableSpec {
     suite("Virgil Test Suite") {
       CqlInterpolatorSpec.cqlInterpolatorSpec +
         (
-          CQLExecutorSpec.sessionSpec +
+          CQLExecutorSpec.executorSpec +
             UserDefinedTypesSpec.userDefinedTypesSpec +
             CollectionsSpec.collectionsSpec +
             CursorSpec.cursorSpec +

--- a/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
@@ -161,25 +161,25 @@ object CQLExecutorSpec {
           .map(numberOfRows => assertTrue(numberOfRows > 0))
           .provideLayer(cqlExecutorLayer)
       } +
-        testM("Exceeding a timeout will cause a failure") {
+        testM("Timeouts are respected") {
           checkM(Gen.chunkOfN(4)(TimeoutCheckRow.gen)) { rows =>
             val insert =
               ZStream
                 .fromIterable(rows)
                 .map(TimeoutCheckRow.insert)
-                .timeout(1.second)
-                .flatMapPar(rows.length / 2)(_.execute)
+                .timeout(4.seconds)
+                .flatMap(_.execute)
 
             val select =
               TimeoutCheckRow.selectAll
-                .timeout(1.second)
+                .timeout(2.second)
                 .execute
                 .runCount
 
             (insert.runDrain *> select)
               .map(c => assertTrue(c == rows.length.toLong))
           }
-        }
+        } @@ samples(1)
     }
 
   // Used to provide a similar API as the `select` method

--- a/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
@@ -26,7 +26,7 @@ object CQLExecutorSpec {
       Any
     ], TestSuccess] =
     suite("Cassandra Session Interpreter Specification") {
-      (queries + actions + configuration) @@ timeout(1.minute) @@ samples(10)
+      (queries + actions + configuration) @@ timeout(3.minutes) @@ samples(4)
     }
 
   def queries: Spec[Has[CQLExecutor] with Random with Sized with TestConfig, TestFailure[Throwable], TestSuccess] =


### PR DESCRIPTION
For example on any CQL datatype:

```scala
cql"SELECT id, info FROM personss WHERE id IN $ids"
  .query[ExecuteTestTable]
  .timeout(10.seconds)
```