### PR TITLE
Preserve chunk structure

### DIFF
--- a/src/main/scala/io/kaizensolutions/virgil/internal/CQLExecutorImpl.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/internal/CQLExecutorImpl.scala
@@ -146,8 +146,8 @@ private[virgil] class CQLExecutorImpl(underlyingSession: CqlSession) extends CQL
         _ <- rs match {
                case _ if rs.hasMorePages =>
                  ref.set(Task.fromCompletionStage(rs.fetchNextPage()).mapError(Option(_)))
-               case _ if rs.currentPage().iterator().hasNext => ref.set(IO.fail(None))
-               case _                                        => IO.fail(None)
+               case _ if rs.remaining() > 0 => ref.set(IO.fail(None))
+               case _                       => IO.fail(None)
              }
       } yield Chunk.fromIterable(rs.currentPage().asScala)
 

--- a/src/test/resources/migrations.cql
+++ b/src/test/resources/migrations.cql
@@ -26,6 +26,12 @@ CREATE TABLE IF NOT EXISTS ziocassandrasessionspec_timeoutcheck
     another_info TEXT
 );
 
+CREATE TABLE IF NOT EXISTS ziocassandrasessionspec_pageSizeCheck
+(
+    id   INT PRIMARY KEY,
+    info TEXT
+);
+
 CREATE TYPE udt_address (
     number INT,
     street TEXT,

--- a/src/test/scala/io/kaizensolutions/virgil/RelationSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/RelationSpec.scala
@@ -31,7 +31,7 @@ object RelationSpec {
         }
       } + testM("isNotNull") {
         checkM(RelationSpec_Person.gen) { person =>
-          val insert = RelationSpec_Person.insert(person).execute.runDrain
+          val insert  = RelationSpec_Person.insert(person).execute.runDrain
           val newName = person.name + " " + person.name
           val update =
             UpdateBuilder(RelationSpec_Person.table)
@@ -54,14 +54,14 @@ object RelationSpec {
 }
 
 final case class RelationSpec_Person(
-    id: Int,
-    name: String,
-    age: Int
+  id: Int,
+  name: String,
+  age: Int
 )
 object RelationSpec_Person {
-  val Id = "id"
+  val Id   = "id"
   val Name = "name"
-  val Age = "age"
+  val Age  = "age"
 
   val table: String = "relationspec_person"
 
@@ -83,8 +83,8 @@ object RelationSpec_Person {
 
   def gen: Gen[Random, RelationSpec_Person] =
     for {
-      id <- Gen.int(1, 1000)
+      id   <- Gen.int(1, 1000)
       name <- Gen.stringBounded(2, 4)(Gen.alphaChar)
-      age <- Gen.int(1, 100)
-    } yield  RelationSpec_Person(id, name, age)
+      age  <- Gen.int(1, 100)
+    } yield RelationSpec_Person(id, name, age)
 }


### PR DESCRIPTION
- .mapM on stream reassembly chunks by single element sized chunks, rewrite it to .mapChunksM
- Rework select paging - don't emit empty chunk. For some reason, for example if we fetch 4 rows by 2 page size we got from cassandra 3 pages where last page is empty (see test)