### PR TITLE
Implement a specialized version of execute for mutations 

### DIFF
--- a/src/main/scala/io/kaizensolutions/virgil/CQL.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQL.scala
@@ -68,6 +68,9 @@ final case class CQL[+Result] private (
 
   def execute: ZStream[Has[CQLExecutor], Throwable, Result] = CQLExecutor.execute(self)
 
+  def executeMutation(implicit ev: Result <:< MutationResult): RIO[Has[CQLExecutor], MutationResult] =
+    CQLExecutor.executeMutation(self.widen[MutationResult])
+
   def executePage[Result1 >: Result](state: Option[PageState] = None): RIO[Has[CQLExecutor], Paged[Result1]] =
     CQLExecutor.executePage(self, state)
 

--- a/src/main/scala/io/kaizensolutions/virgil/CQLExecutor.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQLExecutor.scala
@@ -9,11 +9,16 @@ import zio.{Has, RIO, RLayer, Task, TaskManaged, URLayer, ZIO, ZLayer, ZManaged}
 trait CQLExecutor {
   def execute[A](in: CQL[A]): Stream[Throwable, A]
 
+  def executeMutation(in: CQL[MutationResult]): Task[MutationResult]
+
   def executePage[A](in: CQL[A], pageState: Option[PageState])(implicit ev: A =:!= MutationResult): Task[Paged[A]]
 }
 object CQLExecutor {
   def execute[A](in: CQL[A]): ZStream[Has[CQLExecutor], Throwable, A] =
     ZStream.serviceWithStream(_.execute(in))
+
+  def executeMutation(in: CQL[MutationResult]): RIO[Has[CQLExecutor], MutationResult] =
+    ZIO.serviceWith(_.executeMutation(in))
 
   def executePage[A](in: CQL[A], pageState: Option[PageState] = None)(implicit
     ev: A =:!= MutationResult

--- a/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/CQLExecutorSpec.scala
@@ -129,8 +129,17 @@ object CQLExecutorSpec {
               expected <- expected.runCollect
             } yield assert(actual)(hasSameElements(expected))
           }
+        } +
+        testM("executeMutation") {
+          import ExecuteTestTable._
+          checkM(gen) { data =>
+            val truncateData = truncate(table).executeMutation
+            val toInsert     = insert(table)(data).executeMutation
+            val search       = selectAllIn(table)(data.id :: Nil).execute.runCollect
+            truncateData *> toInsert *> search.map(result => assert(result)(hasSameElements(List(data))))
+          }
         }
-    }
+    } @@ sequential
 
   def configuration
     : Spec[Has[CQLExecutor] with Clock with Random with Sized with TestConfig with Has[CassandraContainer], TestFailure[


### PR DESCRIPTION
Mutations (that we know up-front we will only receive a single resuly back) can now be turned into Tasks directly to avoid the overhead of Stream:

```scala
def truncate(tbl: String): CQL[MutationResult] = CQL.truncate(tbl)
def insert(table: String)(in: ExecuteTestTable): CQL[MutationResult] =
    (cql"INSERT INTO ".appendString(table) ++ cql"(id, info) VALUES (${in.id}, ${in.info})").mutation

val truncateData: RIO[Has[CQLExecutor], MutationResult] = truncate(table).executeMutation
val toInsert: RIO[Has[CQLExecutor], MutationResult] = insert(table)(data).executeMutation
```            