### PR TITLE
Implement support for Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} test
 
       - name: Coverage Coveralls
+        if: ${{ matrix.scala != '3.1.2' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 2.12.15]
+        scala: [2.12.15, 2.13.8, 3.1.2]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -19,3 +19,9 @@ rewriteTokens = {
   "→": "->"
   "←": "<-"
 }
+
+fileOverride {
+  "glob:**/scala-3/**" {
+    runner.dialect = scala3
+  }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ resolvers           += "jitpack" at "https://jitpack.io"
 libraryDependencies += "com.github.kaizen-solutions.virgil" %% "virgil" % "<please-see-jitpack-badge-for-latest-version>"
 ```
 
-Please note that Virgil is only built for Scala 2.12.x and 2.13.x, Scala 3.x support will be coming soon 🥰
+Please note that Virgil is built for Scala 2.12.x, 2.13.x and 3.1.x but fully-automatic derivation is not present for 3.1.x.
 
 ## Introduction
 
@@ -94,6 +94,32 @@ final case class Person(
 
 Note that the `CqlColumn` annotation can be used if the column/field name in the Cassandra table is different from the 
 Scala representation. This can also be used inside User Defined Types as well.
+
+### Scala 3 caveats
+
+If you are using Scala 3.1.x, you will need to use semi-automatic derivation as I have not yet figured out how to enable 
+fully automatic derivation like Scala 2.x has.
+
+```scala3
+final case class Info(favorite: Boolean, comment: String)
+object Info:
+    given cqlUdtValueEncoderForInfo: CqlUdtValueEncoder.Object[Info] = CqlUdtValueEncoder.derive[Info]
+    given cqlUdtValueDecoderForInfo: CqlUdtValueDecoder.Object[Info] = CqlUdtValueDecoder.derive[Info]
+
+final case class Address(street: String, city: String, state: String, zip: Int, data: List[Info])
+object Address:
+    given cqlUdtValueEncoderForAddress: CqlUdtValueEncoder.Object[Address] = CqlUdtValueEncoder.derive[Address]
+    given cqlUdtValueDecoderForAddress: CqlUdtValueDecoder.Object[Address] = CqlUdtValueDecoder.derive[Address]
+
+final case class Person(
+    id: String,
+    name: String,
+    age: Int,
+    @CqlColumn("past_addresses") addresses: Set[Address]
+)
+object Person:
+    given cqlRowDecoderForPersonForPerson: CqlRowDecoder.Object[Person] = CqlRowDecoder.derive[Person]
+```
 
 ### Writing data
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,13 @@
 import ReleaseTransformations._
 
-inThisBuild(
+inThisBuild {
+  val scala212 = "2.12.15"
+  val scala213 = "2.13.8"
+  val scala3   = "3.1.2"
+
   List(
-    scalaVersion                        := "2.13.8",
-    crossScalaVersions                  := Seq("2.13.8", "2.12.15"),
+    scalaVersion                        := scala3,
+    crossScalaVersions                  := Seq(scala212, scala213, scala3),
     githubWorkflowPublishTargetBranches := Seq.empty,
     githubWorkflowBuild += WorkflowStep.Sbt(
       name = Option("Coverage Coveralls"),
@@ -14,7 +18,7 @@ inThisBuild(
       )
     )
   )
-)
+}
 addCommandAlias("coverme", "; clean; coverage; test; coverageReport; coverageAggregate")
 
 lazy val root =
@@ -28,21 +32,29 @@ lazy val root =
         val datastax  = "com.datastax.oss"
         val datastaxV = "4.14.0"
 
-        val zio  = "dev.zio"
-        val zioV = "1.0.14"
+        val zio                   = "dev.zio"
+        val zioV                  = "1.0.14"
+        val magnoliaForScala2     = "com.softwaremill.magnolia1_2" %% "magnolia"      % "1.1.2"
+        val scalaReflectForScala2 = "org.scala-lang"                % "scala-reflect" % scalaVersion.value
+        val magnoliaForScala3     = "com.softwaremill.magnolia1_3" %% "magnolia"      % "1.1.1"
 
-        Seq(
-          datastax                        % "java-driver-core"        % datastaxV,
-          "org.scala-lang.modules"       %% "scala-collection-compat" % "2.7.0",
-          "com.softwaremill.magnolia1_2" %% "magnolia"                % "1.1.2",
-          "org.scala-lang"                % "scala-reflect"           % scalaVersion.value,
-          zio                            %% "zio"                     % zioV,
-          zio                            %% "zio-streams"             % zioV,
-          zio                            %% "zio-test"                % zioV     % Test,
-          zio                            %% "zio-test-sbt"            % zioV     % Test,
-          "com.dimafeng"                 %% "testcontainers-scala"    % "0.40.5" % Test,
-          "com.outr"                     %% "scribe-slf4j"            % "3.8.2"  % Test
-        )
+        val coreDependencies =
+          Seq(
+            datastax                  % "java-driver-core"        % datastaxV,
+            "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
+            zio                      %% "zio"                     % zioV,
+            zio                      %% "zio-streams"             % zioV,
+            zio                      %% "zio-test"                % zioV     % Test,
+            zio                      %% "zio-test-sbt"            % zioV     % Test,
+            "com.dimafeng"           %% "testcontainers-scala"    % "0.40.5" % Test,
+            "com.outr"               %% "scribe-slf4j"            % "3.8.2"  % Test
+          )
+
+        val magnolia =
+          if (scalaVersion.value.startsWith("2")) Seq(magnoliaForScala2, scalaReflectForScala2)
+          else Seq(magnoliaForScala3)
+
+        coreDependencies ++ magnolia
       },
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
       Test / fork                 := true,

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ inThisBuild {
     githubWorkflowBuild += WorkflowStep.Sbt(
       name = Option("Coverage Coveralls"),
       commands = List("clean", "coverage", "test", "coverageReport", "coverageAggregate", "coveralls"),
+      cond = Some("${{ matrix.scala != '3.1.2' }}"),  // Disable coverage for Scala 3.1.2
       env = Map(
         "COVERALLS_REPO_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}",
         "COVERALLS_FLAG_NAME"  -> "Scala ${{ matrix.scala }}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.codecommit"            % "sbt-github-actions" % "0.14.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"       % "0.2.3")
 addSbtPlugin("com.github.sbt"            % "sbt-release"        % "1.1.0")
-addSbtPlugin("org.scoverage"             % "sbt-scoverage"      % "1.9.3")
+addSbtPlugin("org.scoverage"             % "sbt-scoverage"      % "2.0.0-M4")
 addSbtPlugin("org.scoverage"             % "sbt-coveralls"      % "1.3.2")

--- a/src/main/scala-2/io/kaizensolutions/virgil/codecs/RowDecoderMagnoliaDerivation.scala
+++ b/src/main/scala-2/io/kaizensolutions/virgil/codecs/RowDecoderMagnoliaDerivation.scala
@@ -1,0 +1,20 @@
+package io.kaizensolutions.virgil.codecs
+
+import com.datastax.oss.driver.api.core.cql.Row
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1._
+
+trait RowDecoderMagnoliaDerivation {
+  type Typeclass[T] = CqlRowDecoder[T]
+
+  def join[T](ctx: CaseClass[CqlRowDecoder, T]): CqlRowDecoder.Object[T] =
+    new CqlRowDecoder.Object[T] {
+      override def decode(row: Row): T =
+        ctx.construct { p =>
+          val fieldName = CqlColumn.extractFieldName(p.annotations).getOrElse(p.label)
+          p.typeclass.decodeByFieldName(row, fieldName)
+        }
+    }
+
+  implicit def derive[T]: CqlRowDecoder.Object[T] = macro Magnolia.gen[T]
+}

--- a/src/main/scala-2/io/kaizensolutions/virgil/codecs/UdtValueDecoderMagnoliaDerivation.scala
+++ b/src/main/scala-2/io/kaizensolutions/virgil/codecs/UdtValueDecoderMagnoliaDerivation.scala
@@ -1,0 +1,21 @@
+package io.kaizensolutions.virgil.codecs
+
+import com.datastax.oss.driver.api.core.data.UdtValue
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1.{CaseClass, Magnolia}
+
+trait UdtValueDecoderMagnoliaDerivation {
+  type Typeclass[T] = CqlUdtValueDecoder[T]
+
+  def join[T](ctx: CaseClass[CqlUdtValueDecoder, T]): CqlUdtValueDecoder.Object[T] =
+    new CqlUdtValueDecoder.Object[T] {
+      override def decode(structure: UdtValue): T =
+        ctx.construct { param =>
+          val fieldName = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
+          val decoder   = param.typeclass
+          decoder.decodeByFieldName(structure, fieldName)
+        }
+    }
+
+  implicit def derive[T]: CqlUdtValueDecoder.Object[T] = macro Magnolia.gen[T]
+}

--- a/src/main/scala-2/io/kaizensolutions/virgil/codecs/UdtValueEncoderMagnoliaDerivation.scala
+++ b/src/main/scala-2/io/kaizensolutions/virgil/codecs/UdtValueEncoderMagnoliaDerivation.scala
@@ -1,0 +1,22 @@
+package io.kaizensolutions.virgil.codecs
+
+import com.datastax.oss.driver.api.core.data.UdtValue
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1._
+
+trait UdtValueEncoderMagnoliaDerivation {
+  type Typeclass[T] = CqlUdtValueEncoder[T]
+
+  def join[T](ctx: CaseClass[CqlUdtValueEncoder, T]): CqlUdtValueEncoder.Object[T] =
+    new CqlUdtValueEncoder.Object[T] {
+      override def encode(structure: UdtValue, value: T): UdtValue =
+        ctx.parameters.foldLeft(structure) { case (acc, param) =>
+          val fieldName  = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
+          val fieldValue = param.dereference(value)
+          val encoder    = param.typeclass
+          encoder.encodeByFieldName(acc, fieldName, fieldValue)
+        }
+    }
+
+  implicit def derive[T]: CqlUdtValueEncoder.Object[T] = macro Magnolia.gen[T]
+}

--- a/src/main/scala-2/io/kaizensolutions/virgil/cql/ValueInCqlInstances.scala
+++ b/src/main/scala-2/io/kaizensolutions/virgil/cql/ValueInCqlInstances.scala
@@ -1,0 +1,18 @@
+package io.kaizensolutions.virgil.cql
+
+import io.kaizensolutions.virgil.codecs.CqlRowComponentEncoder
+
+trait ValueInCqlInstances {
+
+  /**
+   * This implicit conversion automatically captures the value and evidence of
+   * the type's Writer in a cql interpolated string that is necessary to write
+   * data into the Datastax statement
+   */
+  implicit def toValueInCql[Scala](in: Scala)(implicit encoder: CqlRowComponentEncoder[Scala]): ValueInCql =
+    new ValueInCql {
+      type ScalaType = Scala
+      val value: Scala                          = in
+      val writer: CqlRowComponentEncoder[Scala] = encoder
+    }
+}

--- a/src/main/scala-3/io.kaizensolutions.virgil.codecs/RowDecoderMagnoliaDerivation.scala
+++ b/src/main/scala-3/io.kaizensolutions.virgil.codecs/RowDecoderMagnoliaDerivation.scala
@@ -1,0 +1,17 @@
+package io.kaizensolutions.virgil.codecs
+
+import scala.deriving.Mirror
+import com.datastax.oss.driver.api.core.cql.Row
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1.*
+
+// Note: Fully automatic derivation is not yet present in Scala 3 just yet (because I haven't figured out how to do it yet)
+trait RowDecoderMagnoliaDerivation extends ProductDerivation[CqlRowDecoder]:
+  final def join[T](ctx: CaseClass[Typeclass,T]): CqlRowDecoder.Object[T] = (row: Row) =>
+    ctx.construct { p =>
+      val fieldName = CqlColumn.extractFieldName(p.annotations).getOrElse(p.label)
+      p.typeclass.decodeByFieldName(row, fieldName)
+    }
+
+  inline def derive[A](using Mirror.Of[A]): CqlRowDecoder.Object[A] =
+    derived.asInstanceOf[CqlRowDecoder.Object[A]]

--- a/src/main/scala-3/io.kaizensolutions.virgil.codecs/UdtValueDecoderMagnoliaDerivation.scala
+++ b/src/main/scala-3/io.kaizensolutions.virgil.codecs/UdtValueDecoderMagnoliaDerivation.scala
@@ -1,0 +1,19 @@
+package io.kaizensolutions.virgil.codecs
+
+import scala.deriving.Mirror
+import com.datastax.oss.driver.api.core.data.UdtValue
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1.*
+
+// Note: Fully automatic derivation is not yet present in Scala 3 just yet (because I haven't figured out how to do it yet)
+trait UdtValueDecoderMagnoliaDerivation extends ProductDerivation[CqlUdtValueDecoder]:
+  final def join[T](ctx: CaseClass[Typeclass, T]): CqlUdtValueDecoder.Object[T] =
+    (structure: UdtValue) =>
+      ctx.construct { param =>
+        val fieldName = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
+        val decoder   = param.typeclass
+        decoder.decodeByFieldName(structure, fieldName)
+      }
+
+  inline def derive[A](using Mirror.Of[A]): CqlUdtValueDecoder.Object[A] =
+    derived.asInstanceOf[CqlUdtValueDecoder.Object[A]]

--- a/src/main/scala-3/io.kaizensolutions.virgil.codecs/UdtValueEncoderMagnoliaDerivation.scala
+++ b/src/main/scala-3/io.kaizensolutions.virgil.codecs/UdtValueEncoderMagnoliaDerivation.scala
@@ -1,0 +1,20 @@
+package io.kaizensolutions.virgil.codecs
+
+import scala.deriving.Mirror
+import com.datastax.oss.driver.api.core.data.UdtValue
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import magnolia1._
+
+// Note: Fully automatic derivation is not yet present in Scala 3 just yet (because I haven't figured out how to do it yet)
+trait UdtValueEncoderMagnoliaDerivation extends ProductDerivation[CqlUdtValueEncoder]:
+  final def join[T](ctx: CaseClass[Typeclass,T]): CqlUdtValueEncoder.Object[T] =
+    (structure: UdtValue, value: T) =>
+      ctx.params.foldLeft(structure) { case (acc, param) =>
+        val fieldName  = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
+        val fieldValue = param.deref(value)
+        val encoder    = param.typeclass
+        encoder.encodeByFieldName(acc, fieldName, fieldValue)
+      }
+
+  inline def derive[A](using Mirror.Of[A]): CqlUdtValueEncoder.Object[A] =
+    derived[A].asInstanceOf[CqlUdtValueEncoder.Object[A]]

--- a/src/main/scala-3/io.kaizensolutions.virgil.cql/ValueInCqlInstances.scala
+++ b/src/main/scala-3/io.kaizensolutions.virgil.cql/ValueInCqlInstances.scala
@@ -1,0 +1,11 @@
+package io.kaizensolutions.virgil.cql
+
+import io.kaizensolutions.virgil.codecs.CqlRowComponentEncoder
+
+trait ValueInCqlInstances:
+  given conversionToValueInCql[Scala](using encoder: CqlRowComponentEncoder[Scala]): Conversion[Scala, ValueInCql] =
+    in =>
+      new ValueInCql:
+        type ScalaType = Scala
+        val value: Scala                          = in
+        val writer: CqlRowComponentEncoder[Scala] = encoder

--- a/src/main/scala/io/kaizensolutions/virgil/CQL.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQL.scala
@@ -10,7 +10,7 @@ import zio._
 import zio.duration.Duration
 import zio.stream.ZStream
 
-final case class CQL[+Result] private (
+final case class CQL[+Result](
   private[virgil] val cqlType: CQLType[Result],
   private[virgil] val executionAttributes: ExecutionAttributes
 ) { self =>

--- a/src/main/scala/io/kaizensolutions/virgil/CQLType.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/CQLType.scala
@@ -64,7 +64,7 @@ object CQLType {
 
     final private[virgil] case class Truncate(tableName: String) extends Mutation
 
-    final private[virgil] case class RawCql private (queryString: String, bindMarkers: BindMarkers) extends Mutation
+    final private[virgil] case class RawCql(queryString: String, bindMarkers: BindMarkers) extends Mutation
   }
 
   final private[virgil] case class Batch(mutations: NonEmptyChunk[Mutation], batchType: BatchType)

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveEncoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlPrimitiveEncoder.scala
@@ -302,7 +302,7 @@ object CqlPrimitiveEncoder {
   }
   implicit def scalaTypeViaUdtValuePrimitive[A](implicit
     encoder: CqlUdtValueEncoder.Object[A]
-  ): CqlPrimitiveEncoder[A] =
+  ): CqlPrimitiveEncoder.WithDriver[A, UdtValue] =
     UdtValueEncoderPrimitiveEncoder(encoder)
 
   final case class ListPrimitiveEncoder[Collection[_], ScalaElem, DriverElem](

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlRowDecoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlRowDecoder.scala
@@ -2,8 +2,6 @@ package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.cql.Row
 import io.kaizensolutions.virgil.RowCursor
-import io.kaizensolutions.virgil.annotations.CqlColumn
-import magnolia1._
 
 import scala.util.control.NonFatal
 
@@ -162,6 +160,7 @@ object CqlRowDecoder extends RowDecoderMagnoliaDerivation {
       }
   }
 
+  // $COVERAGE-OFF$Disabling because coverage incorrectly picks this up as untested even though it is
   implicit def tuple1RowDecoder[A](implicit one: CqlPrimitiveDecoder[A]): CqlRowDecoder.Object[Tuple1[A]] =
     new CqlRowDecoder.Object[Tuple1[A]] {
       override def decode(row: Row): Tuple1[A] =
@@ -839,19 +838,5 @@ object CqlRowDecoder extends RowDecoderMagnoliaDerivation {
           CqlPrimitiveDecoder.decodePrimitiveByIndex(structure = row, index = 21)(twentyTwo)
         )
     }
-}
-
-trait RowDecoderMagnoliaDerivation {
-  type Typeclass[T] = CqlRowDecoder[T]
-
-  def join[T](ctx: CaseClass[CqlRowDecoder, T]): CqlRowDecoder.Object[T] =
-    new CqlRowDecoder.Object[T] {
-      override def decode(row: Row): T =
-        ctx.construct { p =>
-          val fieldName = CqlColumn.extractFieldName(p.annotations).getOrElse(p.label)
-          p.typeclass.decodeByFieldName(row, fieldName)
-        }
-    }
-
-  implicit def derive[T]: CqlRowDecoder.Object[T] = macro Magnolia.gen[T]
+  // $COVERAGE-ON$
 }

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlUdtValueDecoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlUdtValueDecoder.scala
@@ -2,8 +2,6 @@ package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.data.UdtValue
 import io.kaizensolutions.virgil.UdtValueCursor
-import io.kaizensolutions.virgil.annotations.CqlColumn
-import magnolia1._
 
 import scala.util.control.NonFatal
 
@@ -841,19 +839,4 @@ object CqlUdtValueDecoder extends UdtValueDecoderMagnoliaDerivation {
           CqlPrimitiveDecoder.decodePrimitiveByIndex(structure = udtValue, index = 21)(twentyTwo)
         )
     }
-}
-trait UdtValueDecoderMagnoliaDerivation {
-  type Typeclass[T] = CqlUdtValueDecoder[T]
-
-  def join[T](ctx: CaseClass[CqlUdtValueDecoder, T]): CqlUdtValueDecoder.Object[T] =
-    new CqlUdtValueDecoder.Object[T] {
-      override def decode(structure: UdtValue): T =
-        ctx.construct { param =>
-          val fieldName = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
-          val decoder   = param.typeclass
-          decoder.decodeByFieldName(structure, fieldName)
-        }
-    }
-
-  implicit def derive[T]: CqlUdtValueDecoder.Object[T] = macro Magnolia.gen[T]
 }

--- a/src/main/scala/io/kaizensolutions/virgil/codecs/CqlUdtValueEncoder.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/codecs/CqlUdtValueEncoder.scala
@@ -2,8 +2,6 @@ package io.kaizensolutions.virgil.codecs
 
 import com.datastax.oss.driver.api.core.`type`.UserDefinedType
 import com.datastax.oss.driver.api.core.data.UdtValue
-import io.kaizensolutions.virgil.annotations.CqlColumn
-import magnolia1._
 
 /**
  * A [[CqlUdtValueEncoder]] encodes a Scala type `A` as a component of a
@@ -72,21 +70,4 @@ object CqlUdtValueEncoder extends UdtValueEncoderMagnoliaDerivation {
       override def encodeByIndex(structure: UdtValue, index: Int, value: A): UdtValue =
         CqlPrimitiveEncoder.encodePrimitiveByIndex(structure, index, value)(prim)
     }
-}
-
-trait UdtValueEncoderMagnoliaDerivation {
-  type Typeclass[T] = CqlUdtValueEncoder[T]
-
-  def join[T](ctx: CaseClass[CqlUdtValueEncoder, T]): CqlUdtValueEncoder.Object[T] =
-    new CqlUdtValueEncoder.Object[T] {
-      override def encode(structure: UdtValue, value: T): UdtValue =
-        ctx.parameters.foldLeft(structure) { case (acc, param) =>
-          val fieldName  = CqlColumn.extractFieldName(param.annotations).getOrElse(param.label)
-          val fieldValue = param.dereference(value)
-          val encoder    = param.typeclass
-          encoder.encodeByFieldName(acc, fieldName, fieldValue)
-        }
-    }
-
-  implicit def derive[T]: CqlUdtValueEncoder.Object[T] = macro Magnolia.gen[T]
 }

--- a/src/main/scala/io/kaizensolutions/virgil/cql/CqlInterpolatedString.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/cql/CqlInterpolatedString.scala
@@ -7,17 +7,18 @@ import io.kaizensolutions.virgil.{CQL, MutationResult}
 import zio.Chunk
 
 import scala.collection.immutable.ListMap
+import scala.collection.mutable
 
 /**
  * CqlInterpolatedString is an intermediate representation that can render
  * itself into the final representation that can be submitted to Cassandra for
  * execution.
  */
-final case class CqlInterpolatedString private (
+final case class CqlInterpolatedString(
   private[cql] val rawQueryRepresentation: Chunk[CqlPartRepr]
 ) {
   private[virgil] def render: (String, ListMap[String, ValueInCql]) = {
-    val queryString         = new StringBuilder
+    val queryString         = new mutable.StringBuilder
     var markers             = ListMap.empty[String, ValueInCql]
     var markerCounter       = 0
     val parameterNamePrefix = "param"

--- a/src/main/scala/io/kaizensolutions/virgil/cql/ValueInCql.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/cql/ValueInCql.scala
@@ -16,21 +16,7 @@ private[virgil] trait ValueInCql {
   override def toString: String =
     value.toString
 }
-object ValueInCql {
+object ValueInCql extends ValueInCqlInstances {
   // Type Refinement
   type WithScalaType[Sc] = ValueInCql { type ScalaType = Sc }
-
-  /**
-   * This implicit conversion automatically captures the value and evidence of
-   * the type's Writer in a cql interpolated string that is necessary to write
-   * data into the Datastax statement
-   */
-  implicit def scalaTypeToValueInCqlInterpolator[Scala](
-    in: Scala
-  )(implicit evidence: CqlRowComponentEncoder[Scala]): ValueInCql.WithScalaType[Scala] =
-    new ValueInCql {
-      type ScalaType = Scala
-      val value: Scala                          = in
-      val writer: CqlRowComponentEncoder[Scala] = evidence
-    }
 }

--- a/src/main/scala/io/kaizensolutions/virgil/internal/QueryType.scala
+++ b/src/main/scala/io/kaizensolutions/virgil/internal/QueryType.scala
@@ -5,13 +5,13 @@ import zio.{Chunk, NonEmptyChunk}
 
 sealed private[virgil] trait QueryType
 object QueryType {
-  final private[virgil] case class Select[FromCassandra](
+  final private[virgil] case class Select(
     tableName: String,
     columnNames: NonEmptyChunk[String],
     relations: Chunk[Relation]
   ) extends QueryType
 
-  final private[virgil] case class RawCql[FromCassandra] private (
+  final private[virgil] case class RawCql(
     query: String,
     columns: BindMarkers
   ) extends QueryType

--- a/src/test/scala-2/io/kaizensolutions/virgil/CollectionsSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/CollectionsSpecDatatypes.scala
@@ -1,0 +1,97 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+object CollectionsSpecDatatypes {
+  final case class SimpleCollectionRow(
+    id: Int,
+    @CqlColumn("map_test") mapTest: Map[Int, String],
+    @CqlColumn("set_test") setTest: Set[Long],
+    @CqlColumn("list_test") listTest: Vector[String]
+  )
+  object SimpleCollectionRow {
+
+    def insert(in: SimpleCollectionRow): CQL[MutationResult] =
+      InsertBuilder("collectionspec_simplecollectiontable")
+        .value("id", in.id)
+        .value("map_test", in.mapTest)
+        .value("set_test", in.setTest)
+        .value("list_test", in.listTest)
+        .build
+
+    def select(id: Int): CQL[SimpleCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_simplecollectiontable")
+        .column("id")
+        .column("map_test")
+        .column("set_test")
+        .column("list_test")
+        .where("id" === id)
+        .build[SimpleCollectionRow]
+
+    val selectAll: CQL[SimpleCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_simplecollectiontable")
+        .columns("id", "map_test", "set_test", "list_test")
+        .build[SimpleCollectionRow]
+  }
+
+  final case class NestedCollectionRow(
+    a: Int,
+    b: Map[Int, Set[Set[Set[Set[Int]]]]]
+  )
+  object NestedCollectionRow {
+
+    def select(a: Int): CQL[NestedCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_nestedcollectiontable")
+        .column("a")
+        .column("b")
+        .where("a" === a)
+        .build[NestedCollectionRow]
+
+    def insert(in: NestedCollectionRow): CQL[MutationResult] =
+      InsertBuilder("collectionspec_nestedcollectiontable")
+        .value("a", in.a)
+        .value("b", in.b)
+        .build
+  }
+
+  final case class OptionCollectionRow(
+    id: Int,
+    @CqlColumn("opt_map_test") m: Option[Map[Int, String]],
+    @CqlColumn("opt_set_test") s: Option[Set[Long]],
+    @CqlColumn("opt_list_test") l: Option[Vector[String]]
+  )
+  object OptionCollectionRow {
+    private val tableName = "collectionspec_optioncollectiontable"
+    def truncate: CQL[MutationResult] =
+      (cql"TRUNCATE " ++ tableName.asCql).mutation
+
+    def insert(in: OptionCollectionRow): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .value("id", in.id)
+        .value("opt_map_test", in.m)
+        .value("opt_set_test", in.s)
+        .value("opt_list_test", in.l)
+        .build
+
+    def select(id: Int): CQL[OptionCollectionRow] =
+      SelectBuilder
+        .from(tableName)
+        .column("id")
+        .column("opt_map_test")
+        .column("opt_set_test")
+        .column("opt_list_test")
+        .where("id" === id)
+        .build[OptionCollectionRow]
+
+    val selectAll: CQL[OptionCollectionRow] =
+      SelectBuilder
+        .from(tableName)
+        .columns("id", "opt_map_test", "opt_set_test", "opt_list_test")
+        .build[OptionCollectionRow]
+  }
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/CqlExecutorSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/CqlExecutorSpecDatatypes.scala
@@ -1,0 +1,84 @@
+package io.kaizensolutions.virgil
+
+import com.datastax.oss.driver.api.core.uuid.Uuids
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+import zio.random.Random
+import zio.test.{Gen, Sized}
+
+import java.nio.ByteBuffer
+import java.util.UUID
+import scala.util.Try
+
+object CqlExecutorSpecDatatypes {
+  final case class SystemLocalResponse(@CqlColumn("system.now()") now: UUID) {
+    def time: Either[Throwable, Long] =
+      Try(Uuids.unixTimestamp(now)).toEither
+  }
+  final case class PreparedStatementsResponse(
+    @CqlColumn("prepared_id") preparedId: ByteBuffer,
+    @CqlColumn("logged_keyspace") keyspace: Option[String],
+    @CqlColumn("query_string") query: String
+  )
+
+  final case class ExecuteTestTable(id: Int, info: String)
+  object ExecuteTestTable {
+    val table      = "ziocassandrasessionspec_executeAction"
+    val batchTable = "ziocassandrasessionspec_executeBatchAction"
+
+    def truncate(tbl: String): CQL[MutationResult] = CQL.truncate(tbl)
+
+    val gen: Gen[Random with Sized, ExecuteTestTable] = for {
+      id   <- Gen.int(1, 1000)
+      info <- Gen.alphaNumericStringBounded(10, 15)
+    } yield ExecuteTestTable(id, info)
+
+    def insert(table: String)(in: ExecuteTestTable): CQL[MutationResult] =
+      (cql"INSERT INTO ".appendString(table) ++ cql"(id, info) VALUES (${in.id}, ${in.info})").mutation
+
+    def selectAllIn(table: String)(ids: List[Int]): CQL[ExecuteTestTable] =
+      (cql"SELECT id, info FROM ".appendString(table) ++ cql" WHERE id IN $ids")
+        .query[ExecuteTestTable]
+  }
+
+  final case class SelectPageRow(id: Int, bucket: Int, info: String)
+  object SelectPageRow {
+    val truncate: CQL[MutationResult] = CQL.truncate("ziocassandrasessionspec_selectPage")
+
+    def insert(in: SelectPageRow): CQL[MutationResult] =
+      cql"INSERT INTO ziocassandrasessionspec_selectPage (id, bucket, info) VALUES (${in.id}, ${in.bucket}, ${in.info})".mutation
+
+    def selectAll: CQL[SelectPageRow] =
+      cql"SELECT id, bucket, info FROM ziocassandrasessionspec_selectPage".query[SelectPageRow]
+  }
+
+  final case class TimeoutCheckRow(id: Int, info: String, @CqlColumn("another_info") anotherInfo: String)
+  object TimeoutCheckRow {
+    val table = "ziocassandrasessionspec_timeoutcheck"
+
+    val selectAll: CQL[TimeoutCheckRow] =
+      s"SELECT id, info, another_info FROM $table".asCql.query[TimeoutCheckRow]
+
+    def insert(in: TimeoutCheckRow): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value("id", in.id)
+        .value("info", in.info)
+        .value("another_info", in.anotherInfo)
+        .build
+  }
+
+  final case class PageSizeCheckRow(id: Int, info: String)
+  object PageSizeCheckRow {
+    val table = "ziocassandrasessionspec_pageSizeCheck"
+
+    val selectAll: CQL[PageSizeCheckRow] =
+      s"SELECT id, info FROM $table".asCql.query[PageSizeCheckRow]
+
+    def insert(in: PageSizeCheckRow): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value("id", in.id)
+        .value("info", in.info)
+        .build
+  }
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/CursorSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/CursorSpecDatatypes.scala
@@ -1,0 +1,45 @@
+package io.kaizensolutions.virgil
+
+import com.datastax.oss.driver.api.core.cql.Row
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.dsl._
+import io.kaizensolutions.virgil.cql._
+import zio.Chunk
+
+import java.net.InetAddress
+
+object CursorSpecDatatypes {
+  final case class CursorExampleRow(
+    id: Long,
+    name: String,
+    age: Short,
+    @CqlColumn("may_be_empty") mayBeEmpty: Option[String],
+    @CqlColumn("addresses") pastAddresses: Chunk[CursorUdtAddress]
+  )
+
+  object CursorExampleRow {
+    val tableName = "cursorspec_cursorexampletable"
+
+    def truncate: CQL[MutationResult] = CQL.truncate(tableName)
+
+    def insert(row: CursorExampleRow): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .values(
+          "id"           -> row.id,
+          "name"         -> row.name,
+          "age"          -> row.age,
+          "addresses"    -> row.pastAddresses,
+          "may_be_empty" -> row.mayBeEmpty
+        )
+        .build
+
+    def select(id: Long): CQL[Row] = {
+      val cql = cql"SELECT * FROM " ++ tableName.asCql ++ cql" WHERE id = $id"
+      cql.query
+    }
+  }
+
+  final case class CursorUdtAddress(street: String, city: String, state: String, zip: String, note: CursorUdtNote)
+
+  final case class CursorUdtNote(data: String, ip: InetAddress)
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/DeleteBuilderSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/DeleteBuilderSpecDatatypes.scala
@@ -1,0 +1,35 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.dsl._
+import zio.NonEmptyChunk
+
+object DeleteBuilderSpecDatatypes {
+  final case class DeleteBuilderSpec_Person(id: Int, name: Option[String], age: Option[Int])
+  object DeleteBuilderSpec_Person {
+    val tableName                         = "deletebuilderspec_person"
+    val Id                                = "id"
+    val Name                              = "name"
+    val Age                               = "age"
+    val AllColumns: NonEmptyChunk[String] = NonEmptyChunk(Id, Name, Age)
+
+    def find(id: Int): CQL[DeleteBuilderSpec_Person] =
+      SelectBuilder
+        .from(tableName)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[DeleteBuilderSpec_Person]
+
+    def insert(in: DeleteBuilderSpec_Person): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .values(
+          Id   -> in.id,
+          Name -> in.name,
+          Age  -> in.age
+        )
+        .ifNotExists
+        .build
+
+    val truncate: CQL[MutationResult] =
+      CQL.truncate(tableName)
+  }
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/InsertBuilderSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/InsertBuilderSpecDatatypes.scala
@@ -1,0 +1,33 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.dsl._
+
+object InsertBuilderSpecDatatypes {
+  final case class InsertBuilderSpecPerson(id: Int, name: String, age: Int)
+  object InsertBuilderSpecPerson {
+    val tableName = "insertbuilderspec_person"
+    val Id        = "id"
+    val Name      = "name"
+    val Age       = "age"
+
+    def truncate: CQL[MutationResult] = CQL.truncate(tableName)
+
+    def insert(in: InsertBuilderSpecPerson): InsertBuilder[InsertState.ColumnAdded] =
+      InsertBuilder(tableName)
+        .values(
+          Id   -> in.id,
+          Name -> in.name,
+          Age  -> in.age
+        )
+
+    def find(id: Int): CQL[InsertBuilderSpecPerson] =
+      SelectBuilder
+        .from(tableName)
+        .allColumns
+        .where(Id === id)
+        .build[InsertBuilderSpecPerson]
+  }
+
+  final case class WriteTimeNameResult(@CqlColumn("writetime(name)") result: Long)
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/RelationSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/RelationSpecDatatypes.scala
@@ -1,0 +1,35 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+object RelationSpecDatatypes {
+  final case class RelationSpec_Person(
+    id: Int,
+    name: String,
+    age: Int
+  )
+  object RelationSpec_Person {
+    val Id   = "id"
+    val Name = "name"
+    val Age  = "age"
+
+    val table: String = "relationspec_person"
+
+    val truncate: CQL[MutationResult] = s"TRUNCATE TABLE $table".asCql.mutation
+
+    def insert(in: RelationSpec_Person): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value(Id, in.id)
+        .value(Name, in.name)
+        .value(Age, in.age)
+        .build
+
+    def find(id: Int): CQL[RelationSpec_Person] =
+      SelectBuilder
+        .from(table)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[RelationSpec_Person]
+  }
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/UpdateBuilderSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/UpdateBuilderSpecDatatypes.scala
@@ -1,0 +1,27 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.dsl._
+
+object UpdateBuilderSpecDatatypes {
+  final case class UpdateBuilderSpecPerson(id: Int, name: String, age: Int)
+  object UpdateBuilderSpecPerson {
+    val tableName: String = "updatebuilderspec_person"
+    val Id                = "id"
+    val Name              = "name"
+    val Age               = "age"
+
+    def find(id: Int) =
+      SelectBuilder
+        .from(tableName)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[UpdateBuilderSpecPerson]
+
+    def insert(in: UpdateBuilderSpecPerson): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .value("id", in.id)
+        .value("name", in.name)
+        .value("age", in.age)
+        .build
+  }
+}

--- a/src/test/scala-2/io/kaizensolutions/virgil/UserDefinedTypesSpecDatatypes.scala
+++ b/src/test/scala-2/io/kaizensolutions/virgil/UserDefinedTypesSpecDatatypes.scala
@@ -1,0 +1,82 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+import java.time.{LocalDate, LocalTime}
+
+object UserDefinedTypesSpecDatatypes {
+  final case class Row_Person(
+    id: Int,
+    name: String,
+    age: Int,
+    data: UDT_Data
+  )
+
+  object Row_Person {
+    def insert(person: Row_Person): CQL[MutationResult] =
+      cql"INSERT INTO userdefinedtypesspec_person (id, name, age, data) VALUES (${person.id}, ${person.name}, ${person.age}, ${person.data})".mutation
+
+    def select(id: Int): CQL[Row_Person] =
+      cql"SELECT id, name, age, data FROM userdefinedtypesspec_person WHERE id = $id".query[Row_Person]
+  }
+
+  final case class UDT_Data(
+    addresses: List[UDT_Address],
+    email: Option[UDT_Email]
+  )
+
+  final case class UDT_Address(
+    number: Int,
+    street: String,
+    city: String
+  )
+
+  final case class UDT_Email(
+    username: String,
+    @CqlColumn("domain_name") domainName: String,
+    domain: String
+  )
+
+  final case class Row_HeavilyNestedUDTTable(
+    id: Int,
+    data: UDT_ExampleCollectionNestedUDTType
+  )
+
+  object Row_HeavilyNestedUDTTable {
+    def insert(in: Row_HeavilyNestedUDTTable): CQL[MutationResult] =
+      InsertBuilder("userdefinedtypesspec_heavilynestedudttable")
+        .value("id", in.id)
+        .value("data", in.data)
+        .build
+
+    def select(id: Int): CQL[Row_HeavilyNestedUDTTable] =
+      SelectBuilder
+        .from("userdefinedtypesspec_heavilynestedudttable")
+        .column("id")
+        .column("data")
+        .where("id" === id)
+        .build[Row_HeavilyNestedUDTTable]
+
+  }
+
+  final case class UDT_ExampleType(
+    x: Long,
+    y: Long,
+    date: LocalDate,
+    time: LocalTime
+  )
+
+  final case class UDT_ExampleNestedType(
+    a: Int,
+    b: String,
+    c: UDT_ExampleType
+  )
+
+  final case class UDT_ExampleCollectionNestedUDTType(
+    a: Int,
+    b: Map[Int, Set[Set[Set[Set[UDT_ExampleNestedType]]]]],
+    c: UDT_ExampleNestedType
+  )
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/CollectionsSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/CollectionsSpecDatatypes.scala
@@ -1,0 +1,106 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.{CQL, MutationResult}
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.codecs.*
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+object CollectionsSpecDatatypes {
+  final case class SimpleCollectionRow(
+    id: Int,
+    @CqlColumn("map_test") mapTest: Map[Int, String],
+    @CqlColumn("set_test") setTest: Set[Long],
+    @CqlColumn("list_test") listTest: Vector[String]
+  )
+  object SimpleCollectionRow {
+    given cqlRowDecoderForSimpleCollectionRow: CqlRowDecoder.Object[SimpleCollectionRow] =
+      CqlRowDecoder.derive[SimpleCollectionRow]
+
+    def insert(in: SimpleCollectionRow): CQL[MutationResult] =
+      InsertBuilder("collectionspec_simplecollectiontable")
+        .value("id", in.id)
+        .value("map_test", in.mapTest)
+        .value("set_test", in.setTest)
+        .value("list_test", in.listTest)
+        .build
+
+    def select(id: Int): CQL[SimpleCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_simplecollectiontable")
+        .column("id")
+        .column("map_test")
+        .column("set_test")
+        .column("list_test")
+        .where("id" === id)
+        .build[SimpleCollectionRow]
+
+    val selectAll: CQL[SimpleCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_simplecollectiontable")
+        .columns("id", "map_test", "set_test", "list_test")
+        .build[SimpleCollectionRow]
+  }
+
+  final case class NestedCollectionRow(
+    a: Int,
+    b: Map[Int, Set[Set[Set[Set[Int]]]]]
+  )
+  object NestedCollectionRow {
+    given cqlRowDecoderForNestedCollectionRow: CqlRowDecoder.Object[NestedCollectionRow] =
+      CqlRowDecoder.derive[NestedCollectionRow]
+
+    def select(a: Int): CQL[NestedCollectionRow] =
+      SelectBuilder
+        .from("collectionspec_nestedcollectiontable")
+        .column("a")
+        .column("b")
+        .where("a" === a)
+        .build[NestedCollectionRow]
+
+    def insert(in: NestedCollectionRow): CQL[MutationResult] =
+      InsertBuilder("collectionspec_nestedcollectiontable")
+        .value("a", in.a)
+        .value("b", in.b)
+        .build
+  }
+
+  final case class OptionCollectionRow(
+    id: Int,
+    @CqlColumn("opt_map_test") m: Option[Map[Int, String]],
+    @CqlColumn("opt_set_test") s: Option[Set[Long]],
+    @CqlColumn("opt_list_test") l: Option[Vector[String]]
+  )
+  object OptionCollectionRow {
+    given cqlRowDecoderForOptionCollectionRow: CqlRowDecoder.Object[OptionCollectionRow] =
+      CqlRowDecoder.derive[OptionCollectionRow]
+
+    private val tableName = "collectionspec_optioncollectiontable"
+    def truncate: CQL[MutationResult] =
+      (cql"TRUNCATE " ++ tableName.asCql).mutation
+
+    def insert(in: OptionCollectionRow): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .value("id", in.id)
+        .value("opt_map_test", in.m)
+        .value("opt_set_test", in.s)
+        .value("opt_list_test", in.l)
+        .build
+
+    def select(id: Int): CQL[OptionCollectionRow] =
+      SelectBuilder
+        .from(tableName)
+        .column("id")
+        .column("opt_map_test")
+        .column("opt_set_test")
+        .column("opt_list_test")
+        .where("id" === id)
+        .build[OptionCollectionRow]
+
+    val selectAll: CQL[OptionCollectionRow] =
+      SelectBuilder
+        .from(tableName)
+        .columns("id", "opt_map_test", "opt_set_test", "opt_list_test")
+        .build[OptionCollectionRow]
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/CqlExecutorSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/CqlExecutorSpecDatatypes.scala
@@ -1,0 +1,106 @@
+package io.kaizensolutions.virgil
+
+import com.datastax.oss.driver.api.core.uuid.Uuids
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+import io.kaizensolutions.virgil.codecs._
+import zio.random.Random
+import zio.test.{Gen, Sized}
+
+import java.nio.ByteBuffer
+import java.util.UUID
+import scala.util.Try
+
+object CqlExecutorSpecDatatypes {
+  final case class SystemLocalResponse(@CqlColumn("system.now()") now: UUID) {
+    def time: Either[Throwable, Long] =
+      Try(Uuids.unixTimestamp(now)).toEither
+  }
+  object SystemLocalResponse {
+    given cqlRowDecoderForSystemLocalResponse: CqlRowDecoder.Object[SystemLocalResponse] =
+      CqlRowDecoder.derive[SystemLocalResponse]
+  }
+
+  final case class PreparedStatementsResponse(
+    @CqlColumn("prepared_id") preparedId: ByteBuffer,
+    @CqlColumn("logged_keyspace") keyspace: Option[String],
+    @CqlColumn("query_string") query: String
+  )
+  object PreparedStatementsResponse {
+    given cqlRowDecoderForPreparedStatementsResponse: CqlRowDecoder.Object[PreparedStatementsResponse] =
+      CqlRowDecoder.derive[PreparedStatementsResponse]
+  }
+
+  final case class ExecuteTestTable(id: Int, info: String)
+  object ExecuteTestTable {
+    given cqlRowDecoderForExecuteTestTable: CqlRowDecoder.Object[ExecuteTestTable] =
+      CqlRowDecoder.derive[ExecuteTestTable]
+
+    val table      = "ziocassandrasessionspec_executeAction"
+    val batchTable = "ziocassandrasessionspec_executeBatchAction"
+
+    def truncate(tbl: String): CQL[MutationResult] = CQL.truncate(tbl)
+
+    val gen: Gen[Random with Sized, ExecuteTestTable] = for {
+      id   <- Gen.int(1, 1000)
+      info <- Gen.alphaNumericStringBounded(10, 15)
+    } yield ExecuteTestTable(id, info)
+
+    def insert(table: String)(in: ExecuteTestTable): CQL[MutationResult] =
+      (cql"INSERT INTO ".appendString(table) ++ cql"(id, info) VALUES (${in.id}, ${in.info})").mutation
+
+    def selectAllIn(table: String)(ids: List[Int]): CQL[ExecuteTestTable] =
+      (cql"SELECT id, info FROM ".appendString(table) ++ cql" WHERE id IN $ids")
+        .query[ExecuteTestTable]
+  }
+
+  final case class SelectPageRow(id: Int, bucket: Int, info: String)
+  object SelectPageRow {
+    given cqlRowDecoderForSelectPageRow: CqlRowDecoder.Object[SelectPageRow] =
+      CqlRowDecoder.derive[SelectPageRow]
+
+    val truncate: CQL[MutationResult] = CQL.truncate("ziocassandrasessionspec_selectPage")
+
+    def insert(in: SelectPageRow): CQL[MutationResult] =
+      cql"INSERT INTO ziocassandrasessionspec_selectPage (id, bucket, info) VALUES (${in.id}, ${in.bucket}, ${in.info})".mutation
+
+    def selectAll: CQL[SelectPageRow] =
+      cql"SELECT id, bucket, info FROM ziocassandrasessionspec_selectPage".query[SelectPageRow]
+  }
+
+  final case class TimeoutCheckRow(id: Int, info: String, @CqlColumn("another_info") anotherInfo: String)
+  object TimeoutCheckRow {
+    given cqlRowDecoderForTimeoutCheckRow: CqlRowDecoder.Object[TimeoutCheckRow] =
+      CqlRowDecoder.derive[TimeoutCheckRow]
+
+    val table = "ziocassandrasessionspec_timeoutcheck"
+
+    val selectAll: CQL[TimeoutCheckRow] =
+      s"SELECT id, info, another_info FROM $table".asCql.query[TimeoutCheckRow]
+
+    def insert(in: TimeoutCheckRow): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value("id", in.id)
+        .value("info", in.info)
+        .value("another_info", in.anotherInfo)
+        .build
+  }
+
+  final case class PageSizeCheckRow(id: Int, info: String)
+  object PageSizeCheckRow {
+    given cqlRowDecoderForPageSizeCheckRow: CqlRowDecoder.Object[PageSizeCheckRow] =
+      CqlRowDecoder.derive[PageSizeCheckRow]
+
+    val table = "ziocassandrasessionspec_pageSizeCheck"
+
+    val selectAll: CQL[PageSizeCheckRow] =
+      s"SELECT id, info FROM $table".asCql.query[PageSizeCheckRow]
+
+    def insert(in: PageSizeCheckRow): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value("id", in.id)
+        .value("info", in.info)
+        .build
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/CursorSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/CursorSpecDatatypes.scala
@@ -1,0 +1,65 @@
+package io.kaizensolutions.virgil
+
+import com.datastax.oss.driver.api.core.cql.Row
+import com.datastax.oss.driver.shaded.guava.common.net.InetAddresses
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.cql.*
+import io.kaizensolutions.virgil.dsl.*
+import io.kaizensolutions.virgil.codecs.*
+import zio.test.*
+import zio.Chunk
+import zio.random.Random
+import java.net.InetAddress
+
+object CursorSpecDatatypes {
+  final case class CursorExampleRow(
+    id: Long,
+    name: String,
+    age: Short,
+    @CqlColumn("may_be_empty") mayBeEmpty: Option[String],
+    @CqlColumn("addresses") pastAddresses: Chunk[CursorUdtAddress]
+  )
+
+  object CursorExampleRow {
+    given cqlRowDecoderForCursorExampleRow: CqlRowDecoder.Object[CursorExampleRow] =
+      CqlRowDecoder.derive[CursorExampleRow]
+
+    val tableName = "cursorspec_cursorexampletable"
+
+    def truncate: CQL[MutationResult] = CQL.truncate(tableName)
+
+    def insert(row: CursorExampleRow): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .values(
+          "id"           -> row.id,
+          "name"         -> row.name,
+          "age"          -> row.age,
+          "addresses"    -> row.pastAddresses,
+          "may_be_empty" -> row.mayBeEmpty
+        )
+        .build
+
+    def select(id: Long): CQL[Row] = {
+      val cql = cql"SELECT * FROM " ++ tableName.asCql ++ cql" WHERE id = $id"
+      cql.query
+    }
+  }
+
+  final case class CursorUdtAddress(street: String, city: String, state: String, zip: String, note: CursorUdtNote)
+  object CursorUdtAddress {
+    given cqlUdtValueDecoderForCursorUdtAddress: CqlUdtValueDecoder.Object[CursorUdtAddress] =
+      CqlUdtValueDecoder.derive[CursorUdtAddress]
+
+    given cqlUdtValueEncoderForCursorUdtAddress: CqlUdtValueEncoder.Object[CursorUdtAddress] =
+      CqlUdtValueEncoder.derive[CursorUdtAddress]
+  }
+
+  final case class CursorUdtNote(data: String, ip: InetAddress)
+  object CursorUdtNote {
+    given cqlUdtValueDecoderForCursorUdtNote: CqlUdtValueDecoder.Object[CursorUdtNote] =
+      CqlUdtValueDecoder.derive[CursorUdtNote]
+
+    given cqlUdtValueEncoderForCursorUdtNote: CqlUdtValueEncoder.Object[CursorUdtNote] =
+      CqlUdtValueEncoder.derive[CursorUdtNote]
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/DeleteBuilderSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/DeleteBuilderSpecDatatypes.scala
@@ -1,0 +1,39 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.codecs.CqlRowDecoder
+import io.kaizensolutions.virgil.dsl._
+import zio.NonEmptyChunk
+
+object DeleteBuilderSpecDatatypes {
+  final case class DeleteBuilderSpec_Person(id: Int, name: Option[String], age: Option[Int])
+  object DeleteBuilderSpec_Person {
+    given cqlRowDecoderForDeleteBuilderSpec_Person: CqlRowDecoder.Object[DeleteBuilderSpec_Person] =
+     CqlRowDecoder.derive[DeleteBuilderSpec_Person]
+
+    val tableName                         = "deletebuilderspec_person"
+    val Id                                = "id"
+    val Name                              = "name"
+    val Age                               = "age"
+    val AllColumns: NonEmptyChunk[String] = NonEmptyChunk(Id, Name, Age)
+
+    def find(id: Int): CQL[DeleteBuilderSpec_Person] =
+      SelectBuilder
+        .from(tableName)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[DeleteBuilderSpec_Person]
+
+    def insert(in: DeleteBuilderSpec_Person): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .values(
+          Id   -> in.id,
+          Name -> in.name,
+          Age  -> in.age
+        )
+        .ifNotExists
+        .build
+
+    val truncate: CQL[MutationResult] =
+      CQL.truncate(tableName)
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/InsertBuilderSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/InsertBuilderSpecDatatypes.scala
@@ -1,0 +1,41 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.codecs.CqlRowDecoder
+import io.kaizensolutions.virgil.dsl._
+
+object InsertBuilderSpecDatatypes {
+  final case class InsertBuilderSpecPerson(id: Int, name: String, age: Int)
+  object InsertBuilderSpecPerson {
+    given cqlRowDecoderForInsertBuilderSpecPerson: CqlRowDecoder.Object[InsertBuilderSpecPerson] =
+      CqlRowDecoder.derive[InsertBuilderSpecPerson]
+
+    val tableName = "insertbuilderspec_person"
+    val Id        = "id"
+    val Name      = "name"
+    val Age       = "age"
+
+    def truncate: CQL[MutationResult] = CQL.truncate(tableName)
+
+    def insert(in: InsertBuilderSpecPerson): InsertBuilder[InsertState.ColumnAdded] =
+      InsertBuilder(tableName)
+        .values(
+          Id   -> in.id,
+          Name -> in.name,
+          Age  -> in.age
+        )
+
+    def find(id: Int): CQL[InsertBuilderSpecPerson] =
+      SelectBuilder
+        .from(tableName)
+        .allColumns
+        .where(Id === id)
+        .build[InsertBuilderSpecPerson]
+  }
+
+  final case class WriteTimeNameResult(@CqlColumn("writetime(name)") result: Long)
+  object WriteTimeNameResult {
+    given cqlRowDecoderForWriteTimeNameResult: CqlRowDecoder.Object[WriteTimeNameResult] =
+      CqlRowDecoder.derive[WriteTimeNameResult]
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/RelationSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/RelationSpecDatatypes.scala
@@ -1,0 +1,39 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.codecs.CqlRowDecoder
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+object RelationSpecDatatypes {
+  final case class RelationSpec_Person(
+    id: Int,
+    name: String,
+    age: Int
+  )
+  object RelationSpec_Person {
+    given cqlRowDecoderForRelationSpec_Person: CqlRowDecoder.Object[RelationSpec_Person] =
+      CqlRowDecoder.derive[RelationSpec_Person]
+
+    val Id   = "id"
+    val Name = "name"
+    val Age  = "age"
+
+    val table: String = "relationspec_person"
+
+    val truncate: CQL[MutationResult] = s"TRUNCATE TABLE $table".asCql.mutation
+
+    def insert(in: RelationSpec_Person): CQL[MutationResult] =
+      InsertBuilder(table)
+        .value(Id, in.id)
+        .value(Name, in.name)
+        .value(Age, in.age)
+        .build
+
+    def find(id: Int): CQL[RelationSpec_Person] =
+      SelectBuilder
+        .from(table)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[RelationSpec_Person]
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/UpdateBuilderSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/UpdateBuilderSpecDatatypes.scala
@@ -1,0 +1,31 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.codecs.CqlRowDecoder
+import io.kaizensolutions.virgil.dsl._
+
+object UpdateBuilderSpecDatatypes {
+  final case class UpdateBuilderSpecPerson(id: Int, name: String, age: Int)
+  object UpdateBuilderSpecPerson {
+    given cqlRowDecoderForUpdateBuilderSpecPerson: CqlRowDecoder.Object[UpdateBuilderSpecPerson] =
+      CqlRowDecoder.derive[UpdateBuilderSpecPerson]
+
+    val tableName: String = "updatebuilderspec_person"
+    val Id                = "id"
+    val Name              = "name"
+    val Age               = "age"
+
+    def find(id: Int) =
+      SelectBuilder
+        .from(tableName)
+        .columns(Id, Name, Age)
+        .where(Id === id)
+        .build[UpdateBuilderSpecPerson]
+
+    def insert(in: UpdateBuilderSpecPerson): CQL[MutationResult] =
+      InsertBuilder(tableName)
+        .value("id", in.id)
+        .value("name", in.name)
+        .value("age", in.age)
+        .build
+  }
+}

--- a/src/test/scala-3/io.kaizensolutions.virgil/UserDefinedTypesSpecDatatypes.scala
+++ b/src/test/scala-3/io.kaizensolutions.virgil/UserDefinedTypesSpecDatatypes.scala
@@ -1,0 +1,123 @@
+package io.kaizensolutions.virgil
+
+import io.kaizensolutions.virgil.annotations.CqlColumn
+import io.kaizensolutions.virgil.codecs.*
+import io.kaizensolutions.virgil.cql._
+import io.kaizensolutions.virgil.dsl._
+
+import java.time.{LocalDate, LocalTime}
+
+object UserDefinedTypesSpecDatatypes {
+  final case class Row_Person(
+    id: Int,
+    name: String,
+    age: Int,
+    data: UDT_Data
+  )
+  object Row_Person {
+    given cqlRowDecoderForRow_Person: CqlRowDecoder.Object[Row_Person] = CqlRowDecoder.derive[Row_Person]
+
+    def insert(person: Row_Person): CQL[MutationResult] =
+      cql"INSERT INTO userdefinedtypesspec_person (id, name, age, data) VALUES (${person.id}, ${person.name}, ${person.age}, ${person.data})".mutation
+
+    def select(id: Int): CQL[Row_Person] =
+      cql"SELECT id, name, age, data FROM userdefinedtypesspec_person WHERE id = $id".query[Row_Person]
+  }
+
+  final case class UDT_Data(
+    addresses: List[UDT_Address],
+    email: Option[UDT_Email]
+  )
+  object UDT_Data {
+    given cqlUdtValueEncoderForUDT_Data: CqlUdtValueEncoder.Object[UDT_Data] = CqlUdtValueEncoder.derive[UDT_Data]
+    given cqlUdtValueDecoderForUDT_Data: CqlUdtValueDecoder.Object[UDT_Data] = CqlUdtValueDecoder.derive[UDT_Data]
+  }
+
+  final case class UDT_Address(
+    number: Int,
+    street: String,
+    city: String
+  )
+  object UDT_Address {
+    given cqlUdtValueEncoderForUDT_Address: CqlUdtValueEncoder.Object[UDT_Address] =
+      CqlUdtValueEncoder.derive[UDT_Address]
+    given cqlUdtValueDecoderForUDT_Address: CqlUdtValueDecoder.Object[UDT_Address] =
+      CqlUdtValueDecoder.derive[UDT_Address]
+  }
+
+  final case class UDT_Email(
+    username: String,
+    @CqlColumn("domain_name") domainName: String,
+    domain: String
+  )
+  object UDT_Email {
+    given cqlUdtValueEncoderForUDT_Email: CqlUdtValueEncoder.Object[UDT_Email] = CqlUdtValueEncoder.derive[UDT_Email]
+    given cqlUdtValueDecoderForUDT_Email: CqlUdtValueDecoder.Object[UDT_Email] = CqlUdtValueDecoder.derive[UDT_Email]
+  }
+
+  final case class Row_HeavilyNestedUDTTable(
+    id: Int,
+    data: UDT_ExampleCollectionNestedUDTType
+  )
+  object Row_HeavilyNestedUDTTable {
+    given cqlRowDecoderForRow_HeavilyNestedUDTTable: CqlRowDecoder.Object[Row_HeavilyNestedUDTTable] =
+      CqlRowDecoder.derive[Row_HeavilyNestedUDTTable]
+
+    def insert(in: Row_HeavilyNestedUDTTable): CQL[MutationResult] =
+      InsertBuilder("userdefinedtypesspec_heavilynestedudttable")
+        .value("id", in.id)
+        .value("data", in.data)
+        .build
+
+    def select(id: Int): CQL[Row_HeavilyNestedUDTTable] =
+      SelectBuilder
+        .from("userdefinedtypesspec_heavilynestedudttable")
+        .column("id")
+        .column("data")
+        .where("id" === id)
+        .build[Row_HeavilyNestedUDTTable]
+
+  }
+
+  final case class UDT_ExampleType(
+    x: Long,
+    y: Long,
+    date: LocalDate,
+    time: LocalTime
+  )
+  object UDT_ExampleType {
+    given cqlUdtValueEncoderForUDT_ExampleType: CqlUdtValueEncoder.Object[UDT_ExampleType] =
+      CqlUdtValueEncoder.derive[UDT_ExampleType]
+
+    given cqlUdtValueDecoderForUDT_ExampleType: CqlUdtValueDecoder.Object[UDT_ExampleType] =
+      CqlUdtValueDecoder.derive[UDT_ExampleType]
+  }
+
+  final case class UDT_ExampleNestedType(
+    a: Int,
+    b: String,
+    c: UDT_ExampleType
+  )
+  object UDT_ExampleNestedType {
+    given cqlUdtValueEncoderForUDT_ExampleNestedType: CqlUdtValueEncoder.Object[UDT_ExampleNestedType] =
+      CqlUdtValueEncoder.derive[UDT_ExampleNestedType]
+
+    given cqlUdtValueDecoderForUDT_ExampleNestedType: CqlUdtValueDecoder.Object[UDT_ExampleNestedType] =
+      CqlUdtValueDecoder.derive[UDT_ExampleNestedType]
+  }
+
+  final case class UDT_ExampleCollectionNestedUDTType(
+    a: Int,
+    b: Map[Int, Set[Set[Set[Set[UDT_ExampleNestedType]]]]],
+    c: UDT_ExampleNestedType
+  )
+  object UDT_ExampleCollectionNestedUDTType {
+    given cqlUdtValueEncoderForUDT_ExampleCollectionNestedUDTType
+      : CqlUdtValueEncoder.Object[UDT_ExampleCollectionNestedUDTType] =
+      CqlUdtValueEncoder.derive[UDT_ExampleCollectionNestedUDTType]
+
+    given cqlUdtValueDecoderForUDT_ExampleCollectionNestedUDTType
+      : CqlUdtValueDecoder.Object[UDT_ExampleCollectionNestedUDTType] =
+      CqlUdtValueDecoder.derive[UDT_ExampleCollectionNestedUDTType]
+  }
+}

--- a/src/test/scala/io/kaizensolutions/virgil/TupleCodecSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/TupleCodecSpec.scala
@@ -13,9 +13,9 @@ object TupleCodecSpec {
         assertM(typeCheck {
           """
           import io.kaizensolutions.virgil.codecs.CqlRowDecoder
-          
-          CqlRowDecoder[Tuple1[String]]   
-          CqlRowDecoder[(String, Int)]  
+
+          CqlRowDecoder[Tuple1[String]]
+          CqlRowDecoder[(String, Int)]
           CqlRowDecoder[(String, Int, Float)]
           CqlRowDecoder[(String, Int, Float, Double)]
           CqlRowDecoder[(String, Int, Float, Double, Boolean)]
@@ -43,9 +43,9 @@ object TupleCodecSpec {
           assertM(typeCheck {
             """
           import io.kaizensolutions.virgil.codecs.CqlUdtValueDecoder
-          
-          CqlUdtValueDecoder[Tuple1[String]]   
-          CqlUdtValueDecoder[(String, Int)]  
+
+          CqlUdtValueDecoder[Tuple1[String]]
+          CqlUdtValueDecoder[(String, Int)]
           CqlUdtValueDecoder[(String, Int, Float)]
           CqlUdtValueDecoder[(String, Int, Float, Double)]
           CqlUdtValueDecoder[(String, Int, Float, Double, Boolean)]

--- a/src/test/scala/io/kaizensolutions/virgil/UpdateBuilderSpec.scala
+++ b/src/test/scala/io/kaizensolutions/virgil/UpdateBuilderSpec.scala
@@ -1,5 +1,6 @@
 package io.kaizensolutions.virgil
 
+import io.kaizensolutions.virgil.UpdateBuilderSpecDatatypes.UpdateBuilderSpecPerson
 import io.kaizensolutions.virgil.dsl._
 import zio.random.Random
 import zio.test.TestAspect._
@@ -10,7 +11,7 @@ object UpdateBuilderSpec {
     suite("UpdateBuilder Specification") {
       testM("Performing an update will upsert a row") {
         import UpdateBuilderSpecPerson._
-        checkM(gen) { person =>
+        checkM(updateBuilderSpecPersonGen) { person =>
           val update =
             UpdateBuilder(tableName)
               .set(Name := person.name)
@@ -25,7 +26,7 @@ object UpdateBuilderSpec {
       } +
         testM("Updating a column (using IF EXISTS) that does not exist will have no effect") {
           import UpdateBuilderSpecPerson._
-          checkM(gen) { person =>
+          checkM(updateBuilderSpecPersonGen) { person =>
             val updatedAge = person.age + 2
             val update =
               UpdateBuilder(tableName)
@@ -42,7 +43,7 @@ object UpdateBuilderSpec {
         } +
         testM("Updating a column using if conditions will update if met") {
           import UpdateBuilderSpecPerson._
-          checkM(gen) { person =>
+          checkM(updateBuilderSpecPersonGen) { person =>
             val updatedAge = person.age + 10
             val update =
               UpdateBuilder(tableName)
@@ -61,30 +62,8 @@ object UpdateBuilderSpec {
           }
         }
     } @@ samples(4) @@ sequential @@ nondeterministic
-}
 
-final case class UpdateBuilderSpecPerson(id: Int, name: String, age: Int)
-object UpdateBuilderSpecPerson {
-  val tableName: String = "updatebuilderspec_person"
-  val Id                = "id"
-  val Name              = "name"
-  val Age               = "age"
-
-  def find(id: Int) =
-    SelectBuilder
-      .from(tableName)
-      .columns(Id, Name, Age)
-      .where(Id === id)
-      .build[UpdateBuilderSpecPerson]
-
-  def insert(in: UpdateBuilderSpecPerson): CQL[MutationResult] =
-    InsertBuilder(tableName)
-      .value("id", in.id)
-      .value("name", in.name)
-      .value("age", in.age)
-      .build
-
-  def gen: Gen[Random with Sized, UpdateBuilderSpecPerson] = for {
+  def updateBuilderSpecPersonGen: Gen[Random with Sized, UpdateBuilderSpecPerson] = for {
     id   <- Gen.int(1, 10000)
     name <- Gen.string(Gen.alphaChar)
     age  <- Gen.int(18, 90)


### PR DESCRIPTION
This PR implements support for Scala 3 and provides semi-automatic derivation out of the box. We cross build for 2.12.x, 2.13.x and now 3.1.x 🥳 

Here is an example of what usage looks like in Scala 3 for codecs:

```scala
final case class Info(favorite: Boolean, comment: String)
object Info:
    given cqlUdtValueEncoderForInfo: CqlUdtValueEncoder.Object[Info] = CqlUdtValueEncoder.derive[Info]
    given cqlUdtValueDecoderForInfo: CqlUdtValueDecoder.Object[Info] = CqlUdtValueDecoder.derive[Info]

final case class Address(street: String, city: String, state: String, zip: Int, data: List[Info])
object Address:
    given cqlUdtValueEncoderForAddress: CqlUdtValueEncoder.Object[Address] = CqlUdtValueEncoder.derive[Address]
    given cqlUdtValueDecoderForAddress: CqlUdtValueDecoder.Object[Address] = CqlUdtValueDecoder.derive[Address]

final case class Person(
    id: String,
    name: String,
    age: Int,
    @CqlColumn("past_addresses") addresses: Set[Address]
)
object Person:
    given cqlRowDecoderForPersonForPerson: CqlRowDecoder.Object[Person] = CqlRowDecoder.derive[Person]
```

Person is a Cassandra row whilst Address and Info are User Defined Types