### PR TITLE
Decrease memory usage

### DIFF
--- a/zio/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
+++ b/zio/src/test/scala/io/kaizensolutions/virgil/AllTests.scala
@@ -24,7 +24,7 @@ object AllTests extends ZIOSpecDefault {
         DeleteBuilderSpec.deleteBuilderSpec +
         InsertBuilderSpec.insertBuilderSpec +
         SelectBuilderSpec.selectBuilderSpec
-    }.provideSomeShared[TestEnvironment](containerLayer, executorLayer, keyspaceAndMigrations) @@ parallel @@ timed
+    }.provideSomeShared[TestEnvironment](containerLayer, executorLayer, keyspaceAndMigrations) @@ sequential @@ timed
 
   val keyspaceAndMigrations =
     ZLayer {

--- a/zio/src/test/scala/io/kaizensolutions/virgil/CassandraContainer.scala
+++ b/zio/src/test/scala/io/kaizensolutions/virgil/CassandraContainer.scala
@@ -65,8 +65,12 @@ object CassandraContainer {
         )
     }
 
+    val customized = container.configure { cont =>
+      val _ = cont.withSharedMemorySize(2048L * 1024L * 1024L)
+    }
+
     ZIO
-      .acquireRelease(ZIO.succeed(container.start()))(_ => ZIO.succeed(container.stop()))
+      .acquireRelease(ZIO.succeed(customized.start()))(_ => ZIO.succeed(customized.stop()))
       .as(
         new CassandraContainer {
           override def getHost: Task[String] = ZIO.attempt(container.host)


### PR DESCRIPTION
Putting an explicit cap on the heap usage (`-Xms256m -Xmx512m`) for the Cassandra Docker image allows us to work in these constrained environments